### PR TITLE
Allow multiple pushes with delays

### DIFF
--- a/FlowStacksApp/Shared/NumberNCoordinator.swift
+++ b/FlowStacksApp/Shared/NumberNCoordinator.swift
@@ -17,12 +17,11 @@ struct NumberNCoordinator: View {
     }
     
     private func showPrevious() {
-        flow.pop()
+        $flow.replaceNFlow(newScreens: [2])
     }
     
     private func showNext() {
-        let index = flow.array.count
-        flow.push(index)
+        $flow.replaceNFlow(newScreens: [5, 8, 13,800, 9])
     }
 }
 

--- a/Sources/FlowStacks/Navigation/NFlow.swift
+++ b/Sources/FlowStacks/Navigation/NFlow.swift
@@ -125,3 +125,28 @@ extension NFlow where Screen: Identifiable & Equatable {
         popTo(id: screen.id)
     }
 }
+
+import SwiftUI
+
+extension Binding {
+  
+  /// This method allows you to replace the NFlow's current screens with a new set of screens. If
+  /// the number of screens is increased greater than is supported within a single SwiftUI update,
+  /// the additional screens will be pushed one at a time.
+  public func replaceNFlow<Screen>(newScreens: [Screen]) where Value == NFlow<Screen> {
+    let oldScreens = wrappedValue.array
+    let numberOfReplacableScreens = oldScreens.count + 1
+    let replacableScreens = newScreens.prefix(numberOfReplacableScreens)
+    let remainingScreens = numberOfReplacableScreens < newScreens.count ? newScreens.suffix(from: numberOfReplacableScreens) : []
+    
+    wrappedValue.replaceNFlow(with: Array(replacableScreens))
+    for (index, screen) in remainingScreens.enumerated() {
+      // There doesn't seem to be a hook to dispatch code when the navigation animation has
+      // completed, so a hardcoded delay is used instead.
+      DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(650 * (index + 1))) {
+        self.wrappedValue.push(screen)
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
This is a draft PR exploring the idea (suggested by @maximkrouk in #3) of overcoming SwiftUI's limitations on how many screens can be pushed in one update by pushing screens one at a time after a delay. 