### PR TITLE
Expose the `onDismiss` closure when presenting a sheet.

### DIFF
--- a/Sources/FlowStacks/Combined/Binding+withDelaysIfUnsupported.swift
+++ b/Sources/FlowStacks/Combined/Binding+withDelaysIfUnsupported.swift
@@ -14,7 +14,7 @@ public extension Route {
     switch self {
     case .push:
       return .push
-    case .sheet(_, let embedInNavigationView):
+    case .sheet(_, let embedInNavigationView, _):
       return .sheet(embedInNavigationView: embedInNavigationView)
     case .cover(_, let embedInNavigationView):
       return .cover(embedInNavigationView: embedInNavigationView)

--- a/Sources/FlowStacks/Combined/Node.swift
+++ b/Sources/FlowStacks/Combined/Node.swift
@@ -42,6 +42,15 @@ indirect enum Node<Screen, V: View>: View {
       return .constant(false)
     }
   }
+
+  private var sheetOnDismiss: (() -> Void)? {
+    switch next {
+    case .route(.sheet(_, _, let onDismiss), _, _, _, _):
+        return onDismiss
+    default:
+        return nil
+    }
+  }
   
   private var coverBinding: Binding<Bool> {
     switch next {
@@ -88,7 +97,7 @@ indirect enum Node<Screen, V: View>: View {
       )
       .sheet(
         isPresented: sheetBinding,
-        onDismiss: nil,
+        onDismiss: sheetOnDismiss,
         content: { next }
       )
       .cover(

--- a/Sources/FlowStacks/Combined/RoutableCollection+utilities.swift
+++ b/Sources/FlowStacks/Combined/RoutableCollection+utilities.swift
@@ -39,8 +39,8 @@ public extension RoutableCollection where Element: RouteProtocol {
 
   /// Presents a new screen via a sheet presentation.
   /// - Parameter screen: The screen to push.
-  mutating func presentSheet(_ screen: Element.Screen, embedInNavigationView: Bool = false) {
-    _append(element: .sheet(screen, embedInNavigationView: embedInNavigationView))
+  mutating func presentSheet(_ screen: Element.Screen, embedInNavigationView: Bool = false, onDismiss: (() -> Void)? = nil) {
+    _append(element: .sheet(screen, embedInNavigationView: embedInNavigationView, onDismiss: onDismiss))
   }
 
   #if os(macOS)

--- a/Sources/FlowStacks/Combined/Route.swift
+++ b/Sources/FlowStacks/Combined/Route.swift
@@ -10,7 +10,7 @@ public enum Route<Screen> {
   /// A sheet presentation.
   /// - Parameter screen: the screen to be shown.
   /// - Parameter embedInNavigationView: whether the presented screen should be embedded in a `NavigationView`.
-  case sheet(Screen, embedInNavigationView: Bool)
+  case sheet(Screen, embedInNavigationView: Bool, onDismiss: (() -> Void)? = nil)
   
   /// A full-screen cover presentation.
   /// - Parameter screen: the screen to be shown.
@@ -21,14 +21,14 @@ public enum Route<Screen> {
   /// The root of the stack. The presentation style is irrelevant as it will not be presented.
   /// - Parameter screen: the screen to be shown.
   public static func root(_ screen: Screen, embedInNavigationView: Bool = false) -> Route {
-    return .sheet(screen, embedInNavigationView: embedInNavigationView)
+    return .sheet(screen, embedInNavigationView: embedInNavigationView, onDismiss: nil)
   }
   
   /// The screen to be shown.
   public var screen: Screen {
     get {
       switch self {
-      case .push(let screen), .sheet(let screen, _), .cover(let screen, _):
+      case .push(let screen), .sheet(let screen, _, _), .cover(let screen, _):
         return screen
       }
     }
@@ -36,8 +36,8 @@ public enum Route<Screen> {
       switch self {
       case .push:
         self = .push(newValue)
-      case .sheet(_, let embedInNavigationView):
-        self = .sheet(newValue, embedInNavigationView: embedInNavigationView)
+      case .sheet(_, let embedInNavigationView, let onDismiss):
+        self = .sheet(newValue, embedInNavigationView: embedInNavigationView, onDismiss: onDismiss)
         #if os(macOS)
         #else
         case .cover(_, let embedInNavigationView):
@@ -52,7 +52,7 @@ public enum Route<Screen> {
     switch self {
     case .push:
       return false
-    case .sheet(_, let embedInNavigationView), .cover(_, let embedInNavigationView):
+    case .sheet(_, let embedInNavigationView, _), .cover(_, let embedInNavigationView):
       return embedInNavigationView
     }
   }
@@ -71,8 +71,8 @@ public enum Route<Screen> {
     switch self {
     case .push:
       return .push(transform(screen))
-    case .sheet(_, let embedInNavigationView):
-      return .sheet(transform(screen), embedInNavigationView: embedInNavigationView)
+    case .sheet(_, let embedInNavigationView, let onDismiss):
+      return .sheet(transform(screen), embedInNavigationView: embedInNavigationView, onDismiss: onDismiss)
 #if os(macOS)
 #else
     case .cover(_, let embedInNavigationView):
@@ -87,7 +87,7 @@ extension Route: Equatable where Screen: Equatable {
     switch (lhs, rhs) {
     case (.push(let left), .push(let right)):
       return left == right
-    case (.sheet(let left, let leftEmbed), .sheet(let right, let rightEmbed)), (.cover(let left, let leftEmbed), .cover(let right, let rightEmbed)):
+    case (.sheet(let left, let leftEmbed, _), .sheet(let right, let rightEmbed, _)), (.cover(let left, let leftEmbed), .cover(let right, let rightEmbed)):
       return left == right && leftEmbed == rightEmbed
     default:
       return false

--- a/Sources/FlowStacks/Combined/RouteProtocol.swift
+++ b/Sources/FlowStacks/Combined/RouteProtocol.swift
@@ -6,7 +6,7 @@ public protocol RouteProtocol {
   associatedtype Screen
   
   static func push(_ screen: Screen) -> Self
-  static func sheet(_ screen: Screen, embedInNavigationView: Bool) -> Self
+  static func sheet(_ screen: Screen, embedInNavigationView: Bool, onDismiss: (() -> Void)?) -> Self
 #if os(macOS)
 // Full-screen cover unavailable.
 #else
@@ -23,7 +23,7 @@ public extension RouteProtocol {
   /// A sheet presentation.
   /// - Parameter screen: the screen to be shown.
   static func sheet(_ screen: Screen) -> Self {
-    return sheet(screen, embedInNavigationView: false)
+    return sheet(screen, embedInNavigationView: false, onDismiss: nil)
   }
   
 #if os(macOS)
@@ -40,7 +40,7 @@ public extension RouteProtocol {
   /// The root of the stack. The presentation style is irrelevant as it will not be presented.
   /// - Parameter screen: the screen to be shown.
   static func root(_ screen: Screen, embedInNavigationView: Bool = false) -> Self {
-    return sheet(screen, embedInNavigationView: embedInNavigationView)
+    return sheet(screen, embedInNavigationView: embedInNavigationView, onDismiss: nil)
   }
 }
   


### PR DESCRIPTION
This PR:
Add an optional `onDismiss` closure to the `presentSheet` method to pass it to the native sheet method instead of passing `nil`. This address the issue described here [No way to know when a sheet is dismissed #14](https://github.com/johnpatrickmorgan/FlowStacks/issues/14)