### PR TITLE
Fix regression onDismiss property not used due to conflicts with another MR

### DIFF
--- a/Sources/FlowStacks/Combined/Node.swift
+++ b/Sources/FlowStacks/Combined/Node.swift
@@ -102,12 +102,12 @@ indirect enum Node<Screen, V: View>: View {
         )
         .sheet(
           isPresented: sheetBinding,
-          onDismiss: nil,
+          onDismiss: onDismiss,
           content: { next }
         )
         .cover(
           isPresented: coverBinding,
-          onDismiss: nil,
+          onDismiss: onDismiss,
           content: { next }
         )
     } else {
@@ -120,7 +120,7 @@ indirect enum Node<Screen, V: View>: View {
         .present(
           asSheet: asSheet,
           isPresented: asSheet ? sheetBinding : coverBinding,
-          onDismiss: nil,
+          onDismiss: onDismiss,
           content: { next }
         )
     }


### PR DESCRIPTION
This MR:
`onDismiss` passed to `nil` (https://github.com/johnpatrickmorgan/FlowStacks/commit/a9a3dcf6545b52c397e8b60931de01f92dd86c99) when fixing Adds a workaround for pre-iOS 14.5 presentation (https://github.com/johnpatrickmorgan/FlowStacks/issues/12)
