### PR TITLE
Manage navigation manually

### DIFF
--- a/FlowStacksApp.xcodeproj/project.pbxproj
+++ b/FlowStacksApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4209924C281654980089B42E /* ManualCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4209924B281654980089B42E /* ManualCoordinator.swift */; };
+		4209924D281654980089B42E /* ManualCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4209924B281654980089B42E /* ManualCoordinator.swift */; };
 		5241BF6F26AA1E8A002D6892 /* FlowStacks in Frameworks */ = {isa = PBXBuildFile; productRef = 5241BF6E26AA1E8A002D6892 /* FlowStacks */; };
 		5241BF7126AA1E8F002D6892 /* FlowStacks in Frameworks */ = {isa = PBXBuildFile; productRef = 5241BF7026AA1E8F002D6892 /* FlowStacks */; };
 		525C733527729300009CBD67 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = 525C733427729300009CBD67 /* SwiftUINavigation */; };
@@ -28,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4209924B281654980089B42E /* ManualCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualCoordinator.swift; sourceTree = "<group>"; };
 		5241BF3326AA1D3B002D6892 /* FlowStacksApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FlowStacksApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5241BF3926AA1D3B002D6892 /* FlowStacksApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FlowStacksApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		525C73362774BA6B009CBD67 /* NumberCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NumberCoordinator.swift; sourceTree = "<group>"; };
@@ -101,6 +104,7 @@
 			children = (
 				526D9F3226AF667000B6B882 /* FlowStacksApp.swift */,
 				525C73362774BA6B009CBD67 /* NumberCoordinator.swift */,
+				4209924B281654980089B42E /* ManualCoordinator.swift */,
 				526D9F2226AF661F00B6B882 /* VMCoordinator.swift */,
 				525C7340277BC788009CBD67 /* ShowingCoordinator.swift */,
 				525C73392774BDB7009CBD67 /* BindingCoordinator.swift */,
@@ -219,6 +223,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4209924C281654980089B42E /* ManualCoordinator.swift in Sources */,
 				526D9F3326AF667000B6B882 /* FlowStacksApp.swift in Sources */,
 				526D9F2E26AF661F00B6B882 /* VMCoordinator.swift in Sources */,
 				525C733A2774BDB7009CBD67 /* BindingCoordinator.swift in Sources */,
@@ -231,6 +236,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4209924D281654980089B42E /* ManualCoordinator.swift in Sources */,
 				526D9F3426AF667000B6B882 /* FlowStacksApp.swift in Sources */,
 				526D9F2F26AF661F00B6B882 /* VMCoordinator.swift in Sources */,
 				525C733B2774BDB7009CBD67 /* BindingCoordinator.swift in Sources */,

--- a/FlowStacksApp/Shared/FlowStacksApp.swift
+++ b/FlowStacksApp/Shared/FlowStacksApp.swift
@@ -13,6 +13,8 @@ struct FlowStacksApp: App {
           .tabItem { Text("Binding") }
         ShowingCoordinator()
           .tabItem { Text("Showing") }
+        ManualCoordinator()
+          .tabItem { Text("Manual") }
       }
     }
   }

--- a/FlowStacksApp/Shared/ManualCoordinator.swift
+++ b/FlowStacksApp/Shared/ManualCoordinator.swift
@@ -1,0 +1,80 @@
+import FlowStacks
+import SwiftUI
+import SwiftUINavigation
+
+enum ManualScreen: Equatable {
+    case details(Int)
+    case contactUs
+}
+
+struct SideBar: View {
+    var onTap: (Int) -> Void
+
+    var body: some View {
+        List(1...10, id: \.self) { index in
+            Text("Item \(index)")
+                .onTapGesture {
+                    onTap(index)
+                }
+        }
+    }
+}
+
+struct ContactUsView: View {
+    var body: some View {
+        Text("Contact us")
+    }
+}
+
+struct DetailsView: View {
+    var number: Int = 0
+    var onTapContact: () -> Void
+    var goToNext: (Int) -> Void
+    var goBack: () -> Void
+    var body: some View {
+      VStack {
+        Text("Item \(number)")
+        Button("Contact us") {
+            onTapContact()
+        }
+        Button("Push next") {
+            goToNext(number + 1)
+        }
+        Button("Go back", action: goBack)
+      }
+    }
+}
+
+struct ManualCoordinator: View {
+    @State var routes: Routes<ManualScreen> = [.root(.details(0), embedInNavigationView: false, manualNavigation: true)]
+
+    var body: some View {
+        HStack {
+            SideBar { index in
+                routes = [.root(.details(index), embedInNavigationView: false, manualNavigation: true)]
+            }.frame(width: 300)
+            Router($routes) { screen, index in
+                switch screen {
+                case .details(let number):
+                    DetailsView(number: number) {
+                        routes.push(.contactUs, manualNavigation: true)
+                    } goToNext: { newNum in
+                        routes.push(.details(newNum), manualNavigation: true)
+                    } goBack: {
+                      if index != 0 {
+                        routes.goBack()
+                      }
+                    }
+                case .contactUs:
+                    ContactUsView()
+                }
+            }.frame(maxWidth: .infinity)
+        }
+    }
+}
+
+struct ManualCoordinator_Previews: PreviewProvider {
+    static var previews: some View {
+        ManualCoordinator()
+    }
+}

--- a/FlowStacksApp/Shared/ManualCoordinator.swift
+++ b/FlowStacksApp/Shared/ManualCoordinator.swift
@@ -3,78 +3,167 @@ import SwiftUI
 import SwiftUINavigation
 
 enum ManualScreen: Equatable {
-    case details(Int)
-    case contactUs
+  case details(Int)
+  case contactUs
 }
 
 struct SideBar: View {
-    var onTap: (Int) -> Void
-
-    var body: some View {
-        List(1...10, id: \.self) { index in
-            Text("Item \(index)")
-                .onTapGesture {
-                    onTap(index)
-                }
+  var pushNative: () -> Void
+  var pushManual: () -> Void
+  
+  var body: some View {
+    List {
+      Text("Native NavigationView")
+        .onTapGesture {
+          pushNative()
+        }
+      Text("Manual Navigation")
+        .onTapGesture {
+          pushManual()
         }
     }
+  }
 }
 
 struct ContactUsView: View {
-    var body: some View {
-        Text("Contact us")
+  var goBack: (() -> Void)?
+  var body: some View {
+    VStack {
+      Text("Contact us")
+      if let goBack = goBack {
+        Button("Back", action: goBack)
+      }
     }
+  }
 }
 
 struct DetailsView: View {
-    var number: Int = 0
-    var onTapContact: () -> Void
-    var goToNext: (Int) -> Void
-    var goBack: () -> Void
-    var body: some View {
-      VStack {
-        Text("Item \(number)")
-        Button("Contact us") {
-            onTapContact()
-        }
-        Button("Push next") {
-            goToNext(number + 1)
-        }
-        Button("Go back", action: goBack)
-      }
+  @Binding var number: Int
+  var pushContact: () -> Void
+  let presentDoubleCover: (Int) -> Void
+  let presentDoubleSheet: (Int) -> Void
+  let pushNext: (Int) -> Void
+  let goBack: (() -> Void)?
+  let goBackToRoot: () -> Void
+  let goRandom: (() -> Void)?
+
+  var body: some View {
+    VStack {
+      NumberView(
+        number: $number,
+        presentDoubleCover: presentDoubleCover,
+        presentDoubleSheet: presentDoubleSheet,
+        pushNext: pushNext,
+        goBack: goBack,
+        goBackToRoot: goBackToRoot,
+        goRandom: goRandom
+      )
+      Button("Contact us", action: pushContact)
     }
+  }
 }
 
 struct ManualCoordinator: View {
-    @State var routes: Routes<ManualScreen> = [.root(.details(0), embedInNavigationView: false, manualNavigation: true)]
-
-    var body: some View {
-        HStack {
-            SideBar { index in
-                routes = [.root(.details(index), embedInNavigationView: false, manualNavigation: true)]
-            }.frame(width: 300)
-            Router($routes) { screen, index in
-                switch screen {
-                case .details(let number):
-                    DetailsView(number: number) {
-                        routes.push(.contactUs, manualNavigation: true)
-                    } goToNext: { newNum in
-                        routes.push(.details(newNum), manualNavigation: true)
-                    } goBack: {
-                      if index != 0 {
-                        routes.goBack()
-                      }
-                    }
-                case .contactUs:
-                    ContactUsView()
-                }
-            }.frame(maxWidth: .infinity)
+  @State var routes: Routes<ManualScreen> = [.root(.details(0), embedInNavigationView: true)]
+  
+  var randomRoutes: [Route<ManualScreen>] {
+    let options: [[Route<ManualScreen>]] = [
+      [.root(.details(0), manualNavigation: true)],
+      [
+        .root(.details(0), manualNavigation: true),
+        .push(.details(1), manualNavigation: true),
+        .push(.details(2), manualNavigation: true),
+        .push(.details(3), manualNavigation: true),
+        .sheet(.details(4), embedInNavigationView: false, manualNavigation: true),
+        .push(.details(5), manualNavigation: true)
+      ],
+      [
+        .root(.details(0), manualNavigation: true),
+        .push(.details(1), manualNavigation: true),
+        .push(.details(2), manualNavigation: true),
+        .push(.details(3), manualNavigation: true)
+      ],
+      [
+        .root(.details(0), manualNavigation: true),
+        .push(.details(1), manualNavigation: true),
+        .sheet(.details(2), embedInNavigationView: false, manualNavigation: true),
+        .push(.details(3), manualNavigation: true),
+        .sheet(.details(4), embedInNavigationView: true),
+        .push(.details(5))
+      ],
+      [
+        .root(.details(0), manualNavigation: true),
+        .sheet(.details(1), embedInNavigationView: true),
+        .cover(.details(2), embedInNavigationView: true),
+        .push(.details(3)),
+        .sheet(.details(4), embedInNavigationView: true),
+        .push(.details(5))
+      ]
+    ]
+    return options.randomElement()!
+  }
+  
+  var body: some View {
+    HStack {
+      SideBar(
+        pushNative: {
+          routes = [.root(.details(0), embedInNavigationView: true)]
+        },
+        pushManual: {
+          routes = [.root(.details(0), manualNavigation: true)]
         }
+      ).frame(width: 300)
+      VStack {
+        Router($routes) { $screen, index in
+          switch screen {
+          case .details:
+            if let number = Binding(unwrapping: $screen, case: /ManualScreen.details) {
+              DetailsView(
+                number: number,
+                pushContact: {
+                  routes.push(.contactUs)
+                },
+                presentDoubleCover: { number in
+                  #if os(macOS)
+                  routes.presentSheet(.details(number * 2), manualNavigation: true)
+                  #else
+                  routes.presentSheet(.details(number * 2), embedInNavigationView: true)
+                  #endif
+                },
+                presentDoubleSheet: { number in
+                  #if os(macOS)
+                  routes.presentSheet(.details(number * 2), manualNavigation: true)
+                  #else
+                  routes.presentSheet(.details(number * 2), embedInNavigationView: true)
+                  #endif
+                },
+                pushNext: { number in
+                  routes.push(.details(number + 1))
+                },
+                goBack: index != 0 ? { routes.goBack() } : nil,
+                goBackToRoot: {
+                  $routes.withDelaysIfUnsupported {
+                    $0.goBackToRoot()
+                  }
+                },
+                goRandom: {
+                  $routes.withDelaysIfUnsupported {
+                    $0 = randomRoutes
+                  }
+                }
+              )
+            }
+          case .contactUs:
+            ContactUsView(goBack: index != 0 ? { routes.goBack() } : nil)
+          }
+        }.frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
     }
+  }
 }
 
 struct ManualCoordinator_Previews: PreviewProvider {
-    static var previews: some View {
-        ManualCoordinator()
-    }
+  static var previews: some View {
+    ManualCoordinator()
+  }
 }

--- a/Sources/FlowStacks/Binding+withDelaysIfUnsupported.swift
+++ b/Sources/FlowStacks/Binding+withDelaysIfUnsupported.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// The style with which a route is shown, i.e., if the route is pushed, presented
 /// as a sheet or presented as a full-screen cover.
 public enum RouteStyle: Hashable {
-  case push, sheet(embedInNavigationView: Bool), cover(embedInNavigationView: Bool)
+  case push, sheet(embedInNavigationView: Bool, manualNavigation: Bool = false), cover(embedInNavigationView: Bool)
   
   public var isSheet: Bool {
     switch self {
@@ -32,8 +32,8 @@ public extension Route {
     switch self {
     case .push:
       return .push
-    case .sheet(_, let embedInNavigationView, _):
-      return .sheet(embedInNavigationView: embedInNavigationView)
+    case .sheet(_, let embedInNavigationView, let manualNavigation, _):
+      return .sheet(embedInNavigationView: embedInNavigationView, manualNavigation: manualNavigation)
     case .cover(_, let embedInNavigationView, _):
       return .cover(embedInNavigationView: embedInNavigationView)
     }

--- a/Sources/FlowStacks/Node.swift
+++ b/Sources/FlowStacks/Node.swift
@@ -90,52 +90,42 @@ indirect enum Node<Screen, V: View>: View {
   }
   
   @ViewBuilder
+  private var manualNavigationView: some View {
+    switch next {
+    case .route(.push(_, manualNavigation: true), _, _, _, _), .route(.sheet(_, _, manualNavigation: true, _), _, _, _, _):
+      if isActiveBinding.wrappedValue {
+        next
+      } else {
+        screenView
+      }
+    default:
+      screenView
+    }
+  }
+  
+  @ViewBuilder
   private var manualNavigationBody: some View {
     if #available(iOS 14.5, *) {
-      if isActiveBinding.wrappedValue {
-        next
-          .sheet(
-            isPresented: sheetBinding,
-            onDismiss: onDismiss,
-            content: { next }
-          )
-          .cover(
-            isPresented: coverBinding,
-            onDismiss: onDismiss,
-            content: { next }
-          )
-      } else {
-        screenView
-          .sheet(
-            isPresented: sheetBinding,
-            onDismiss: onDismiss,
-            content: { next }
-          )
-          .cover(
-            isPresented: coverBinding,
-            onDismiss: onDismiss,
-            content: { next }
-          )
-      }
+      manualNavigationView
+        .sheet(
+          isPresented: sheetBinding,
+          onDismiss: onDismiss,
+          content: { next }
+        )
+        .cover(
+          isPresented: coverBinding,
+          onDismiss: onDismiss,
+          content: { next }
+        )
     } else {
       let asSheet = next?.route?.style.isSheet ?? false
-      if isActiveBinding.wrappedValue {
-        next
-          .present(
-            asSheet: asSheet,
-            isPresented: asSheet ? sheetBinding : coverBinding,
-            onDismiss: onDismiss,
-            content: { next }
-          )
-      } else {
-        screenView
-          .present(
-            asSheet: asSheet,
-            isPresented: asSheet ? sheetBinding : coverBinding,
-            onDismiss: onDismiss,
-            content: { next }
-          )
-      }
+      manualNavigationView
+        .present(
+          asSheet: asSheet,
+          isPresented: asSheet ? sheetBinding : coverBinding,
+          onDismiss: onDismiss,
+          content: { next }
+        )
     }
   }
   

--- a/Sources/FlowStacks/RoutableCollection+utilities.swift
+++ b/Sources/FlowStacks/RoutableCollection+utilities.swift
@@ -9,13 +9,22 @@ public extension RoutableCollection where Element: RouteProtocol {
       switch route.style {
       case .push:
         continue
-      case .cover(let embedInNavigationView), .sheet(let embedInNavigationView):
+      case .cover(let embedInNavigationView):
         if index > 0 {
           return embedInNavigationView
         } else {
           // Once we reach the root screen, it's not possible to determine if the routes are being pushed onto a
           // parent coordinator with a NavigationView, so we return nil rather than false.
           return embedInNavigationView ? true : nil
+        }
+      case .sheet(let embedInNavigationView, let manualNavigation):
+        let canNavigate = embedInNavigationView || manualNavigation
+        if index > 0 {
+          return canNavigate
+        } else {
+          // Once we reach the root screen, it's not possible to determine if the routes are being pushed onto a
+          // parent coordinator with a NavigationView, so we return nil rather than false.
+          return canNavigate ? true : nil
         }
       }
     }
@@ -25,7 +34,7 @@ public extension RoutableCollection where Element: RouteProtocol {
   /// Pushes a new screen via a push navigation.
   /// This should only be called if the most recently presented screen is embedded in a `NavigationView`.
   /// - Parameter screen: The screen to push.
-  mutating func push(_ screen: Element.Screen) {
+  mutating func push(_ screen: Element.Screen, manualNavigation: Bool = false) {
     assert(
       canPush != false,
       """
@@ -34,14 +43,14 @@ public extension RoutableCollection where Element: RouteProtocol {
       route has `embedInNavigationView` set to `true`.
       """
     )
-    _append(element: .push(screen))
+    _append(element: .push(screen, manualNavigation: manualNavigation))
   }
-
+  
   /// Presents a new screen via a sheet presentation.
   /// - Parameter screen: The screen to push.
   /// - Parameter onDismiss: A closure to be invoked when the screen is dismissed.
-  mutating func presentSheet(_ screen: Element.Screen, embedInNavigationView: Bool = false, onDismiss: (() -> Void)? = nil) {
-    _append(element: .sheet(screen, embedInNavigationView: embedInNavigationView, onDismiss: onDismiss))
+  mutating func presentSheet(_ screen: Element.Screen, embedInNavigationView: Bool = false, manualNavigation: Bool = false, onDismiss: (() -> Void)? = nil) {
+    _append(element: .sheet(screen, embedInNavigationView: embedInNavigationView, manualNavigation: manualNavigation, onDismiss: onDismiss))
   }
 
   #if os(macOS)

--- a/Sources/FlowStacks/RouteProtocol.swift
+++ b/Sources/FlowStacks/RouteProtocol.swift
@@ -5,8 +5,8 @@ import Foundation
 public protocol RouteProtocol {
   associatedtype Screen
   
-  static func push(_ screen: Screen) -> Self
-  static func sheet(_ screen: Screen, embedInNavigationView: Bool, onDismiss: (() -> Void)?) -> Self
+  static func push(_ screen: Screen, manualNavigation: Bool) -> Self
+  static func sheet(_ screen: Screen, embedInNavigationView: Bool, manualNavigation: Bool, onDismiss: (() -> Void)?) -> Self
 #if os(macOS)
 // Full-screen cover unavailable.
 #else
@@ -23,7 +23,7 @@ public extension RouteProtocol {
   /// A sheet presentation.
   /// - Parameter screen: the screen to be shown.
   static func sheet(_ screen: Screen) -> Self {
-    return sheet(screen, embedInNavigationView: false, onDismiss: nil)
+      return sheet(screen, embedInNavigationView: false, manualNavigation: false, onDismiss: nil)
   }
   
 #if os(macOS)
@@ -39,8 +39,8 @@ public extension RouteProtocol {
   
   /// The root of the stack. The presentation style is irrelevant as it will not be presented.
   /// - Parameter screen: the screen to be shown.
-  static func root(_ screen: Screen, embedInNavigationView: Bool = false) -> Self {
-    return sheet(screen, embedInNavigationView: embedInNavigationView, onDismiss: nil)
+  static func root(_ screen: Screen, embedInNavigationView: Bool = false, manualNavigation: Bool = false) -> Self {
+      return sheet(screen, embedInNavigationView: embedInNavigationView, manualNavigation: false, onDismiss: nil)
   }
 }
   


### PR DESCRIPTION
This PR:
* Add `manualNavigation` to `Route` that allows user to create their own navigation flow without using Apple's native `NavigationView`
* Add new example screen `Manual` to demonstrate using `manualNavigation` in both iOS and macOS

This addresses issue #22 

iOS:

https://user-images.githubusercontent.com/4270232/165051259-680d3c3e-26fb-4ba4-9641-5acd3487295e.mp4

macOS:

https://user-images.githubusercontent.com/4270232/165051229-a5679de8-723c-473e-86a1-b8ef3caa9207.mov



