### PR TITLE
Add async-await support and parent-child coordinator example

### DIFF
--- a/FlowStacksApp.xcodeproj/project.pbxproj
+++ b/FlowStacksApp.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		526D9F3426AF667000B6B882 /* FlowStacksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526D9F3226AF667000B6B882 /* FlowStacksApp.swift */; };
 		526D9F7B26AF6C1700B6B882 /*  in Resources */ = {isa = PBXBuildFile; fileRef = 526D9F7A26AF6BE900B6B882 /*  */; };
 		526D9F7C26AF6C1700B6B882 /*  in Resources */ = {isa = PBXBuildFile; fileRef = 526D9F7A26AF6BE900B6B882 /*  */; };
+		77F136ED282E45E0008A6A02 /* ParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F136EC282E45DF008A6A02 /* ParentCoordinator.swift */; };
+		77F136EE282E45E0008A6A02 /* ParentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F136EC282E45DF008A6A02 /* ParentCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,6 +39,7 @@
 		526D9F2226AF661F00B6B882 /* VMCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VMCoordinator.swift; sourceTree = "<group>"; };
 		526D9F3226AF667000B6B882 /* FlowStacksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowStacksApp.swift; sourceTree = "<group>"; };
 		526D9F7A26AF6BE900B6B882 /*  */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ""; sourceTree = "<group>"; };
+		77F136EC282E45DF008A6A02 /* ParentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +102,7 @@
 		526D9F1D26AF661F00B6B882 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				77F136EC282E45DF008A6A02 /* ParentCoordinator.swift */,
 				526D9F3226AF667000B6B882 /* FlowStacksApp.swift */,
 				525C73362774BA6B009CBD67 /* NumberCoordinator.swift */,
 				526D9F2226AF661F00B6B882 /* VMCoordinator.swift */,
@@ -221,6 +225,7 @@
 			files = (
 				526D9F3326AF667000B6B882 /* FlowStacksApp.swift in Sources */,
 				526D9F2E26AF661F00B6B882 /* VMCoordinator.swift in Sources */,
+				77F136EE282E45E0008A6A02 /* ParentCoordinator.swift in Sources */,
 				525C733A2774BDB7009CBD67 /* BindingCoordinator.swift in Sources */,
 				525C73372774BA6B009CBD67 /* NumberCoordinator.swift in Sources */,
 				525C7341277BC788009CBD67 /* ShowingCoordinator.swift in Sources */,
@@ -233,6 +238,7 @@
 			files = (
 				526D9F3426AF667000B6B882 /* FlowStacksApp.swift in Sources */,
 				526D9F2F26AF661F00B6B882 /* VMCoordinator.swift in Sources */,
+				77F136ED282E45E0008A6A02 /* ParentCoordinator.swift in Sources */,
 				525C733B2774BDB7009CBD67 /* BindingCoordinator.swift in Sources */,
 				525C73382774BA6B009CBD67 /* NumberCoordinator.swift in Sources */,
 				525C7342277BC788009CBD67 /* ShowingCoordinator.swift in Sources */,

--- a/FlowStacksApp/Shared/FlowStacksApp.swift
+++ b/FlowStacksApp/Shared/FlowStacksApp.swift
@@ -5,6 +5,8 @@ struct FlowStacksApp: App {
   var body: some Scene {
     WindowGroup {
       TabView {
+        ParentCoordinator()
+          .tabItem { Text("Parent") }
         NumberCoordinator()
           .tabItem { Text("Numbers") }
         VMCoordinator()

--- a/FlowStacksApp/Shared/NumberCoordinator.swift
+++ b/FlowStacksApp/Shared/NumberCoordinator.swift
@@ -43,13 +43,17 @@ struct NumberCoordinator: View {
           },
           goBack: index != 0 ? { routes.goBack() } : nil,
           goBackToRoot: {
-            $routes.withDelaysIfUnsupported {
-              $0.goBackToRoot()
+            Task { @MainActor in
+              await $routes.withDelaysIfUnsupported {
+                $0.goBackToRoot()
+              }
             }
           },
           goRandom: {
-            $routes.withDelaysIfUnsupported {
-              $0 = randomRoutes
+            Task { @MainActor in
+              await $routes.withDelaysIfUnsupported {
+                $0 = randomRoutes
+              }
             }
           }
         )

--- a/FlowStacksApp/Shared/ParentCoordinator.swift
+++ b/FlowStacksApp/Shared/ParentCoordinator.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import FlowStacks
+
+struct ParentCoordinator: View {
+
+  enum Screen {
+    case home
+    case childFlowOne
+    case childFlowTwo
+  }
+
+	@State var routes: Routes<Screen> = [.root(.home)]
+
+  var body: some View {
+    Router($routes) { screen, _ in
+      switch screen {
+      case .home:
+        ContainerCoordinatorHomeView(
+          goToFlowOne: { routes.presentCover(.childFlowOne) },
+          goToFlowTwo: { routes.presentCover(.childFlowTwo) }
+        )
+      case .childFlowOne:
+        ChildFlowCoordinator(flowTitle: "Flow 1", completeFlow: {
+          completeFlow()
+        })
+      case .childFlowTwo:
+        ChildFlowCoordinator(flowTitle: "Flow 2", completeFlow: {
+          completeFlow()
+        })
+      }
+    }
+  }
+
+  private func completeFlow() {
+    Task { @MainActor in
+      await $routes.withDelaysIfUnsupported {
+        $0.goBackToRoot()
+      }
+    }
+  }
+}
+
+struct ContainerCoordinatorHomeView: View {
+
+  let goToFlowOne: () -> Void
+  let goToFlowTwo: () -> Void
+
+  var body: some View {
+    VStack {
+      Button("Go to flow one", action: goToFlowOne).padding()
+      Button("Go to flow two", action: goToFlowTwo)
+    }
+  }
+}
+
+struct ChildFlowCoordinator: View {
+
+  enum Screen {
+    case first
+    case second
+  }
+
+  let flowTitle: String
+  let completeFlow: () -> Void
+
+  @State var routes: Routes<Screen> = [.root(.first)]
+
+  var body: some View {
+    Router($routes) { screen, _ in
+      switch screen {
+      case .first:
+        ChildFlowFirstView(
+          title: (flowTitle + ": " + "Flow's First Step"),
+          closeFlow: closeFlow,
+          goToFlowsSecondStep: { routes.presentSheet(.second) }
+        )
+      case .second:
+        ChildFlowSecondView(
+          title: (flowTitle + ": " + "Flow's Second Step"),
+          closeFlow: closeFlow,
+          goBackToCurrentFlowRoot: goBackToCurrentFlowRoot
+        )
+      }
+    }
+  }
+
+  private func closeFlow() {
+    Task { @MainActor in
+      await $routes.withDelaysIfUnsupported {
+        $0.goBackToRoot()
+      }
+      completeFlow()
+    }
+  }
+
+  private func goBackToCurrentFlowRoot() {
+    Task { @MainActor in
+      await $routes.withDelaysIfUnsupported {
+        $0.goBackToRoot()
+      }
+    }
+  }
+}
+
+struct ChildFlowSecondView: View {
+
+  let title: String
+  let closeFlow: () -> Void
+  let goBackToCurrentFlowRoot: () -> Void
+
+  var body: some View {
+    VStack {
+      Text(title).font(.headline).padding()
+      Button("Go back to start of flow", action: goBackToCurrentFlowRoot).padding()
+      Button("Close Flow", action: closeFlow)
+    }
+  }
+}
+
+struct ChildFlowFirstView: View {
+
+  let title: String
+  let closeFlow: () -> Void
+  let goToFlowsSecondStep: () -> Void
+
+  var body: some View {
+    VStack {
+      Text(title).font(.headline).padding()
+      Button("Go to flow's second view", action: goToFlowsSecondStep).padding()
+      Button("Close Flow", action: closeFlow)
+    }
+  }
+}

--- a/FlowStacksApp/Shared/ShowingCoordinator.swift
+++ b/FlowStacksApp/Shared/ShowingCoordinator.swift
@@ -17,14 +17,16 @@ struct ShowingCoordinator: View {
             routes.presentSheet(number * 2 , embedInNavigationView: true)
           },
           pushNext: { number in
-            routes.push(number + 1)
-          },
-          goBack: { routes.goBack() },
-          goBackToRoot: {
-            $routes.withDelaysIfUnsupported {
-              $0 = []
-            }
-          },
+						routes.push(number + 1)
+					},
+					goBack: { routes.goBack() },
+					goBackToRoot: {
+						Task { @MainActor in
+							await $routes.withDelaysIfUnsupported {
+								$0 = []
+							}
+						}
+					},
           goRandom: nil
         )
       }

--- a/FlowStacksApp/Shared/VMCoordinator.swift
+++ b/FlowStacksApp/Shared/VMCoordinator.swift
@@ -27,8 +27,10 @@ class VMCoordinatorViewModel: ObservableObject {
   }
   
   func goBackToRoot() {
-    RouteSteps.withDelaysIfUnsupported(self, \.routes) {
-      $0.goBackToRoot()
+    Task { @MainActor in
+      await RouteSteps.withDelaysIfUnsupported(self, \.routes) {
+        $0.goBackToRoot()
+      }
     }
   }
 }


### PR DESCRIPTION
This PR improves the logic behind the function `withDelaysIfUnsupported` by utilising the new async-await APIs. Also it adds a more comprehensive example of Parent Coordinator that itself has other Coordinators as children. With the proposed PR it will also now be possible to dismiss child coordinators with their separate flows by delegating dismissal to the Parent coordinator, hence improving the library's usage for more complex modular multi feature project setups where each feature could live in a separate module and have its own Coordinator.