### PR TITLE
Show root, go back to root only if needed

### DIFF
--- a/Sources/FlowStacks/RoutableCollection+utilities.swift
+++ b/Sources/FlowStacks/RoutableCollection+utilities.swift
@@ -84,6 +84,7 @@ public extension RoutableCollection where Element: RouteProtocol {
   /// Goes back to the root screen (index 0). The resulting screen count
   /// will be 1.
   mutating func goBackToRoot() {
+    guard self.count > 1 else { return }
     goBackTo(index: 0)
   }
 


### PR DESCRIPTION
It doesn't make sense IMO to get an assert when going back to root if the root is already presented. Or is there any other way to show the initial screen (for e.g. deeplink handling):

```
$routes.withDelaysIfUnsupported {
    $0.dismiss()
    $0.goBackToRoot()
}
```