### PR TITLE
Update podspec version to 0.2.5

### DIFF
--- a/FlowStacks.podspec
+++ b/FlowStacks.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name             = 'FlowStacks'
-  s.version          = '0.2.1'
+  s.version          = '0.2.5'
   s.summary          = 'Hoist navigation state into a coordinator in SwiftUI.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
I would like to update the podspec version so latest version FlowStacks could be used with CocoaPods as well.
(Tagging as 0.2.5 and  then `pod repo push` is needed.)