### PR TITLE
Update podspec version to 0.3.2

### DIFF
--- a/FlowStacks.podspec
+++ b/FlowStacks.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name             = 'FlowStacks'
-  s.version          = '0.2.5'
+  s.version          = '0.3.2'
   s.summary          = 'Hoist navigation state into a coordinator in SwiftUI.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
I would like to update the podspec file so that CocoaPods users can use the latest version of the library. After the merge, tagging with 0.3.2 and then `pod repo push` is needed.