### PR TITLE
Feature/missing feature add to router accent color support

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/FlowStacks.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FlowStacks.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FlowStacksTests"
+               BuildableName = "FlowStacksTests"
+               BlueprintName = "FlowStacksTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Sources/FlowStacks/Node.swift
+++ b/Sources/FlowStacks/Node.swift
@@ -2,96 +2,99 @@ import Foundation
 import SwiftUI
 
 struct Node<Screen, V: View>: View {
-  @Binding var allScreens: [Route<Screen>]
-  let buildView: (Binding<Screen>, Int) -> V
-  let truncateToIndex: (Int) -> Void
-  let index: Int
-  let screen: Screen?
-  
-  // NOTE: even though this object is unused, its inclusion avoids a glitch when swiping to dismiss
-  // a sheet that's been presented from a pushed screen with a view model.
-  @EnvironmentObject var navigator: FlowNavigator<Screen>
+    @Binding var allScreens: [Route<Screen>]
+    let buildView: (Binding<Screen>, Int) -> V
+    let truncateToIndex: (Int) -> Void
+    let index: Int
+    let screen: Screen?
+    let accentColor: Color?
 
-  @State var isAppeared = false
+    // NOTE: even though this object is unused, its inclusion avoids a glitch when swiping to dismiss
+    // a sheet that's been presented from a pushed screen with a view model.
+    @EnvironmentObject var navigator: FlowNavigator<Screen>
 
-  init(allScreens: Binding<[Route<Screen>]>, truncateToIndex: @escaping (Int) -> Void, index: Int, buildView: @escaping (Binding<Screen>, Int) -> V) {
-    _allScreens = allScreens
-    self.truncateToIndex = truncateToIndex
-    self.index = index
-    self.buildView = buildView
-    screen = allScreens.wrappedValue[safe: index]?.screen
-  }
+    @State var isAppeared = false
 
-  private var isActiveBinding: Binding<Bool> {
-    return Binding(
-      get: { allScreens.count > index + 1 },
-      set: { isShowing in
-        guard !isShowing else { return }
-        guard allScreens.count > index + 1 else { return }
-        guard isAppeared else { return }
-        truncateToIndex(index + 1)
-      }
-    )
-  }
-
-  var next: some View {
-    Node(allScreens: $allScreens, truncateToIndex: truncateToIndex, index: index + 1, buildView: buildView)
-  }
-  
-  var nextRoute: Route<Screen>? {
-    allScreens[safe: index + 1]
-  }
-
-  @ViewBuilder
-  var content: some View {
-    if let screen = allScreens[safe: index]?.screen ?? screen {
-      let screenBinding = Binding<Screen>(
-        get: { allScreens[safe: index]?.screen ?? screen },
-        set: { allScreens[index].screen = $0 }
-      )
-      buildView(screenBinding, index)
-        .pushing(
-          isActive: nextRoute?.style == .push ? isActiveBinding : .constant(false),
-          destination: next
-        )
-        .presenting(
-          sheetBinding: (nextRoute?.style.isSheet ?? false) ? isActiveBinding : .constant(false),
-          coverBinding: (nextRoute?.style.isCover ?? false) ? isActiveBinding : .constant(false),
-          destination: next,
-          onDismiss: nextRoute?.onDismiss
-        )
-        .onAppear { isAppeared = true }
-        .onDisappear { isAppeared = false }
+    init(allScreens: Binding<[Route<Screen>]>, accentColor: Color?, truncateToIndex: @escaping (Int) -> Void, index: Int, buildView: @escaping (Binding<Screen>, Int) -> V) {
+        _allScreens = allScreens
+        self.truncateToIndex = truncateToIndex
+        self.index = index
+        self.buildView = buildView
+        self.accentColor = accentColor
+        screen = allScreens.wrappedValue[safe: index]?.screen
     }
-  }
-  
-  var body: some View {
-    let route = allScreens[safe: index]
-    if route?.embedInNavigationView ?? false {
-      NavigationView {
-        content
-      }
-      .navigationViewStyle(supportedNavigationViewStyle)
-    } else {
-      content
+
+    private var isActiveBinding: Binding<Bool> {
+        return Binding(
+            get: { allScreens.count > index + 1 },
+            set: { isShowing in
+                guard !isShowing else { return }
+                guard allScreens.count > index + 1 else { return }
+                guard isAppeared else { return }
+                truncateToIndex(index + 1)
+            }
+        )
     }
-  }
+
+    var next: some View {
+        Node(allScreens: $allScreens, accentColor: accentColor, truncateToIndex: truncateToIndex, index: index + 1, buildView: buildView)
+    }
+
+    var nextRoute: Route<Screen>? {
+        allScreens[safe: index + 1]
+    }
+
+    @ViewBuilder
+    var content: some View {
+        if let screen = allScreens[safe: index]?.screen ?? screen {
+            let screenBinding = Binding<Screen>(
+                get: { allScreens[safe: index]?.screen ?? screen },
+                set: { allScreens[index].screen = $0 }
+            )
+            buildView(screenBinding, index)
+                .pushing(
+                    isActive: nextRoute?.style == .push ? isActiveBinding : .constant(false),
+                    destination: next
+                )
+                .presenting(
+                    sheetBinding: (nextRoute?.style.isSheet ?? false) ? isActiveBinding : .constant(false),
+                    coverBinding: (nextRoute?.style.isCover ?? false) ? isActiveBinding : .constant(false),
+                    destination: next,
+                    onDismiss: nextRoute?.onDismiss
+                )
+                .onAppear { isAppeared = true }
+                .onDisappear { isAppeared = false }
+        }
+    }
+
+    var body: some View {
+        let route = allScreens[safe: index]
+        if route?.embedInNavigationView ?? false {
+            NavigationView {
+                content
+            }
+            .accentColor(accentColor)
+            .navigationViewStyle(supportedNavigationViewStyle)
+        } else {
+            content
+        }
+    }
 }
 
 
 extension Collection {
-  /// Returns the element at the specified index if it is within bounds, otherwise nil.
-  subscript(safe index: Index) -> Element? {
-    return indices.contains(index) ? self[index] : nil
-  }
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript(safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
 }
 
 /// There are spurious state updates when using the `column` navigation view style, so
 /// the navigation view style is forced to `stack` where possible.
 private var supportedNavigationViewStyle: some NavigationViewStyle {
-  #if os(macOS)
+    #if os(macOS)
     .automatic
-  #else
+    #else
     .stack
-  #endif
+    #endif
 }

--- a/Sources/FlowStacks/Node.swift
+++ b/Sources/FlowStacks/Node.swift
@@ -2,99 +2,99 @@ import Foundation
 import SwiftUI
 
 struct Node<Screen, V: View>: View {
-    @Binding var allScreens: [Route<Screen>]
-    let buildView: (Binding<Screen>, Int) -> V
-    let truncateToIndex: (Int) -> Void
-    let index: Int
-    let screen: Screen?
-    let accentColor: Color?
+  @Binding var allScreens: [Route<Screen>]
+  let buildView: (Binding<Screen>, Int) -> V
+  let truncateToIndex: (Int) -> Void
+  let index: Int
+  let screen: Screen?
+  let accentColor: Color?
 
-    // NOTE: even though this object is unused, its inclusion avoids a glitch when swiping to dismiss
-    // a sheet that's been presented from a pushed screen with a view model.
-    @EnvironmentObject var navigator: FlowNavigator<Screen>
+  // NOTE: even though this object is unused, its inclusion avoids a glitch when swiping to dismiss
+  // a sheet that's been presented from a pushed screen with a view model.
+  @EnvironmentObject var navigator: FlowNavigator<Screen>
 
-    @State var isAppeared = false
+  @State var isAppeared = false
 
-    init(allScreens: Binding<[Route<Screen>]>, accentColor: Color?, truncateToIndex: @escaping (Int) -> Void, index: Int, buildView: @escaping (Binding<Screen>, Int) -> V) {
-        _allScreens = allScreens
-        self.truncateToIndex = truncateToIndex
-        self.index = index
-        self.buildView = buildView
-        self.accentColor = accentColor
-        screen = allScreens.wrappedValue[safe: index]?.screen
-    }
+  init(allScreens: Binding<[Route<Screen>]>, accentColor: Color?, truncateToIndex: @escaping (Int) -> Void, index: Int, buildView: @escaping (Binding<Screen>, Int) -> V) {
+    _allScreens = allScreens
+    self.truncateToIndex = truncateToIndex
+    self.index = index
+    self.buildView = buildView
+      self.accentColor = accentColor
+    screen = allScreens.wrappedValue[safe: index]?.screen
+  }
 
-    private var isActiveBinding: Binding<Bool> {
-        return Binding(
-            get: { allScreens.count > index + 1 },
-            set: { isShowing in
-                guard !isShowing else { return }
-                guard allScreens.count > index + 1 else { return }
-                guard isAppeared else { return }
-                truncateToIndex(index + 1)
-            }
+  private var isActiveBinding: Binding<Bool> {
+    return Binding(
+      get: { allScreens.count > index + 1 },
+      set: { isShowing in
+        guard !isShowing else { return }
+        guard allScreens.count > index + 1 else { return }
+        guard isAppeared else { return }
+        truncateToIndex(index + 1)
+      }
+    )
+  }
+
+  var next: some View {
+      Node(allScreens: $allScreens, accentColor: accentColor, truncateToIndex: truncateToIndex, index: index + 1, buildView: buildView)
+  }
+
+  var nextRoute: Route<Screen>? {
+    allScreens[safe: index + 1]
+  }
+
+  @ViewBuilder
+  var content: some View {
+    if let screen = allScreens[safe: index]?.screen ?? screen {
+      let screenBinding = Binding<Screen>(
+        get: { allScreens[safe: index]?.screen ?? screen },
+        set: { allScreens[index].screen = $0 }
+      )
+      buildView(screenBinding, index)
+        .pushing(
+          isActive: nextRoute?.style == .push ? isActiveBinding : .constant(false),
+          destination: next
         )
+        .presenting(
+          sheetBinding: (nextRoute?.style.isSheet ?? false) ? isActiveBinding : .constant(false),
+          coverBinding: (nextRoute?.style.isCover ?? false) ? isActiveBinding : .constant(false),
+          destination: next,
+          onDismiss: nextRoute?.onDismiss
+        )
+        .onAppear { isAppeared = true }
+        .onDisappear { isAppeared = false }
     }
+  }
 
-    var next: some View {
-        Node(allScreens: $allScreens, accentColor: accentColor, truncateToIndex: truncateToIndex, index: index + 1, buildView: buildView)
+  var body: some View {
+    let route = allScreens[safe: index]
+    if route?.embedInNavigationView ?? false {
+      NavigationView {
+        content
+      }
+      .accentColor(accentColor)
+      .navigationViewStyle(supportedNavigationViewStyle)
+    } else {
+      content
     }
-
-    var nextRoute: Route<Screen>? {
-        allScreens[safe: index + 1]
-    }
-
-    @ViewBuilder
-    var content: some View {
-        if let screen = allScreens[safe: index]?.screen ?? screen {
-            let screenBinding = Binding<Screen>(
-                get: { allScreens[safe: index]?.screen ?? screen },
-                set: { allScreens[index].screen = $0 }
-            )
-            buildView(screenBinding, index)
-                .pushing(
-                    isActive: nextRoute?.style == .push ? isActiveBinding : .constant(false),
-                    destination: next
-                )
-                .presenting(
-                    sheetBinding: (nextRoute?.style.isSheet ?? false) ? isActiveBinding : .constant(false),
-                    coverBinding: (nextRoute?.style.isCover ?? false) ? isActiveBinding : .constant(false),
-                    destination: next,
-                    onDismiss: nextRoute?.onDismiss
-                )
-                .onAppear { isAppeared = true }
-                .onDisappear { isAppeared = false }
-        }
-    }
-
-    var body: some View {
-        let route = allScreens[safe: index]
-        if route?.embedInNavigationView ?? false {
-            NavigationView {
-                content
-            }
-            .accentColor(accentColor)
-            .navigationViewStyle(supportedNavigationViewStyle)
-        } else {
-            content
-        }
-    }
+  }
 }
 
 
 extension Collection {
-    /// Returns the element at the specified index if it is within bounds, otherwise nil.
-    subscript(safe index: Index) -> Element? {
-        return indices.contains(index) ? self[index] : nil
-    }
+  /// Returns the element at the specified index if it is within bounds, otherwise nil.
+  subscript(safe index: Index) -> Element? {
+    return indices.contains(index) ? self[index] : nil
+  }
 }
 
 /// There are spurious state updates when using the `column` navigation view style, so
 /// the navigation view style is forced to `stack` where possible.
 private var supportedNavigationViewStyle: some NavigationViewStyle {
-    #if os(macOS)
+  #if os(macOS)
     .automatic
-    #else
+  #else
     .stack
-    #endif
+  #endif
 }

--- a/Sources/FlowStacks/Router.swift
+++ b/Sources/FlowStacks/Router.swift
@@ -3,45 +3,50 @@ import SwiftUI
 
 /// Router converts an array of pushed / presented routes into a view.
 public struct Router<Screen, ScreenView: View>: View {
-  /// The array of routes that represents the navigation stack.
-  @Binding var routes: [Route<Screen>]
+    /// The array of routes that represents the navigation stack.
+    @Binding var routes: [Route<Screen>]
 
-  /// A closure that builds a `ScreenView` from a `Screen`and its index.
-  @ViewBuilder var buildView: (Binding<Screen>, Int) -> ScreenView
+    /// A closure that builds a `ScreenView` from a `Screen`and its index.
+    @ViewBuilder var buildView: (Binding<Screen>, Int) -> ScreenView
 
-  
-  /// Initializer for creating a Router using a binding to an array of screens.
-  /// - Parameters:
-  ///   - stack: A binding to an array of screens.
-  ///   - buildView: A closure that builds a `ScreenView` from a binding to a `Screen` and its index.
-  public init(_ routes: Binding<[Route<Screen>]>, @ViewBuilder buildView: @escaping (Binding<Screen>, Int) -> ScreenView) {
-    self._routes = routes
-    self.buildView = buildView
-  }
-  
-  public var body: some View {
-    Node(allScreens: $routes, truncateToIndex: { index in routes = Array(routes.prefix(index)) }, index: 0, buildView: buildView)
-      .environmentObject(FlowNavigator($routes))
-  }
+    let accentColor: Color?
+
+    /// Initializer for creating a Router using a binding to an array of screens.
+    /// - Parameters:
+    ///   - stack: A binding to an array of screens.
+    ///   - buildView: A closure that builds a `ScreenView` from a binding to a `Screen` and its index.
+    public init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Binding<Screen>, Int) -> ScreenView) {
+        self._routes = routes
+        self.buildView = buildView
+        self.accentColor = accentColor
+    }
+
+    public var body: some View {
+        Node(allScreens: $routes, accentColor: accentColor, truncateToIndex: { index in routes = Array(routes.prefix(index)) }, index: 0, buildView: buildView)
+            .environmentObject(FlowNavigator($routes))
+    }
 }
 
 public extension Router {
-  /// Initializer for creating a Router using a binding to an array of screens.
-  /// - Parameters:
-  ///   - stack: A binding to an array of screens.
-  ///   - buildView: A closure that builds a `ScreenView` from a `Screen` and its index.
-  init(_ routes: Binding<[Route<Screen>]>, @ViewBuilder buildView: @escaping (Screen, Int) -> ScreenView) {
-    self._routes = routes
-    self.buildView = { buildView($0.wrappedValue, $1) }
-  }
-  
-  init(_ routes: Binding<[Route<Screen>]>, @ViewBuilder buildView: @escaping (Binding<Screen>) -> ScreenView) {
-    self._routes = routes
-    self.buildView = { screen, _ in buildView(screen) }
-  }
-  
-  init(_ routes: Binding<[Route<Screen>]>, @ViewBuilder buildView: @escaping (Screen) -> ScreenView) {
-    self._routes = routes
-    self.buildView = { $screen, _ in buildView(screen) }
-  }
+    /// Initializer for creating a Router using a binding to an array of screens.
+    /// - Parameters:
+    ///   - stack: A binding to an array of screens.
+    ///   - buildView: A closure that builds a `ScreenView` from a `Screen` and its index.
+    init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Screen, Int) -> ScreenView) {
+        self._routes = routes
+        self.buildView = { buildView($0.wrappedValue, $1) }
+        self.accentColor = accentColor
+    }
+
+    init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Binding<Screen>) -> ScreenView) {
+        self._routes = routes
+        self.buildView = { screen, _ in buildView(screen) }
+        self.accentColor = accentColor
+    }
+
+    init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Screen) -> ScreenView) {
+        self._routes = routes
+        self.buildView = { $screen, _ in buildView(screen) }
+        self.accentColor = accentColor
+    }
 }

--- a/Sources/FlowStacks/Router.swift
+++ b/Sources/FlowStacks/Router.swift
@@ -3,50 +3,50 @@ import SwiftUI
 
 /// Router converts an array of pushed / presented routes into a view.
 public struct Router<Screen, ScreenView: View>: View {
-    /// The array of routes that represents the navigation stack.
-    @Binding var routes: [Route<Screen>]
+  /// The array of routes that represents the navigation stack.
+  @Binding var routes: [Route<Screen>]
 
-    /// A closure that builds a `ScreenView` from a `Screen`and its index.
-    @ViewBuilder var buildView: (Binding<Screen>, Int) -> ScreenView
+  /// A closure that builds a `ScreenView` from a `Screen`and its index.
+  @ViewBuilder var buildView: (Binding<Screen>, Int) -> ScreenView
 
-    let accentColor: Color?
+  let accentColor: Color?
 
-    /// Initializer for creating a Router using a binding to an array of screens.
-    /// - Parameters:
-    ///   - stack: A binding to an array of screens.
-    ///   - buildView: A closure that builds a `ScreenView` from a binding to a `Screen` and its index.
-    public init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Binding<Screen>, Int) -> ScreenView) {
-        self._routes = routes
-        self.buildView = buildView
-        self.accentColor = accentColor
-    }
+  /// Initializer for creating a Router using a binding to an array of screens.
+  /// - Parameters:
+  ///   - stack: A binding to an array of screens.
+  ///   - buildView: A closure that builds a `ScreenView` from a binding to a `Screen` and its index.
+  public init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Binding<Screen>, Int) -> ScreenView) {
+    self._routes = routes
+    self.buildView = buildView
+      self.accentColor = accentColor
+  }
 
-    public var body: some View {
-        Node(allScreens: $routes, accentColor: accentColor, truncateToIndex: { index in routes = Array(routes.prefix(index)) }, index: 0, buildView: buildView)
-            .environmentObject(FlowNavigator($routes))
-    }
+  public var body: some View {
+      Node(allScreens: $routes, accentColor: accentColor, truncateToIndex: { index in routes = Array(routes.prefix(index)) }, index: 0, buildView: buildView)
+          .environmentObject(FlowNavigator($routes))
+  }
 }
 
 public extension Router {
-    /// Initializer for creating a Router using a binding to an array of screens.
-    /// - Parameters:
-    ///   - stack: A binding to an array of screens.
-    ///   - buildView: A closure that builds a `ScreenView` from a `Screen` and its index.
-    init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Screen, Int) -> ScreenView) {
-        self._routes = routes
-        self.buildView = { buildView($0.wrappedValue, $1) }
-        self.accentColor = accentColor
-    }
+  /// Initializer for creating a Router using a binding to an array of screens.
+  /// - Parameters:
+  ///   - stack: A binding to an array of screens.
+  ///   - buildView: A closure that builds a `ScreenView` from a `Screen` and its index.
+  init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Screen, Int) -> ScreenView) {
+    self._routes = routes
+    self.buildView = { buildView($0.wrappedValue, $1) }
+    self.accentColor = accentColor
+  }
 
-    init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Binding<Screen>) -> ScreenView) {
-        self._routes = routes
-        self.buildView = { screen, _ in buildView(screen) }
-        self.accentColor = accentColor
-    }
+  init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Binding<Screen>) -> ScreenView) {
+    self._routes = routes
+    self.buildView = { screen, _ in buildView(screen) }
+    self.accentColor = accentColor
+  }
 
-    init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Screen) -> ScreenView) {
-        self._routes = routes
-        self.buildView = { $screen, _ in buildView(screen) }
-        self.accentColor = accentColor
-    }
+  init(_ routes: Binding<[Route<Screen>]>, accentColor: Color? = nil, @ViewBuilder buildView: @escaping (Screen) -> ScreenView) {
+    self._routes = routes
+    self.buildView = { $screen, _ in buildView(screen) }
+    self.accentColor = accentColor
+  }
 }


### PR DESCRIPTION
If you setup navigation `accentColor` to you root NavigationView it cannot pass `accentColor ` to next NavigationView if you try to present screens with parameter `embedInNavigationView` to `true`.
This pull request resolves lib problem with passing navigation `accentColor` if you present new screen with parameter `embedInNavigationView`.

You can try the solution on my [fork](https://github.com/slawaDnC/FlowStacks)