### PR TITLE
fix: handle nested AnyHashable screen

### DIFF
--- a/Sources/FlowStacks/DestinationBuilderHolder.swift
+++ b/Sources/FlowStacks/DestinationBuilderHolder.swift
@@ -41,7 +41,7 @@ class DestinationBuilderHolder: ObservableObject {
     var key = Self.identifier(for: type(of: base))
     // NOTE: - `wrappedValue` might be nested `AnyHashable` e.g. `AnyHashable<AnyHashable<AnyHashable<MyScreen>>>`.
     // And `base as? AnyHashable` will always produce a `AnyHashable` so we need check if key contains 'AnyHashable' to break the looping.
-    while key.contains("AnyHashable"), let anyHashable = base as? AnyHashable {
+    while key == "Swift.AnyHashable", let anyHashable = base as? AnyHashable {
       base = anyHashable.base
       key = Self.identifier(for: type(of: base))
     }

--- a/Sources/FlowStacks/DestinationBuilderHolder.swift
+++ b/Sources/FlowStacks/DestinationBuilderHolder.swift
@@ -37,7 +37,14 @@ class DestinationBuilderHolder: ObservableObject {
   }
 
   func build(_ binding: Binding<AnyHashable>) -> AnyView {
-    let base = binding.wrappedValue.base
+    var base = binding.wrappedValue.base
+    var key = Self.identifier(for: type(of: base))
+    // NOTE: - `wrappedValue` might be nested `AnyHashable` e.g. `AnyHashable<AnyHashable<AnyHashable<MyScreen>>>`.
+    // And `base as? AnyHashable` will always produce a `AnyHashable` so we need check if key contains 'AnyHashable' to break the looping.
+    while key.contains("AnyHashable"), let anyHashable = base as? AnyHashable {
+      base = anyHashable.base
+      key = Self.identifier(for: type(of: base))
+    }
     if let identifier = base as? LocalDestinationID {
       let key = identifier.rawValue.uuidString
       if let builder = builders[key], let output = builder(binding) {


### PR DESCRIPTION
I ran into an assertion failure: "No view builder found for type Swift.AnyHashable" at `DestinationBuilderHolder.swift`.
It works well on iOS 15 and above. 
But the `binding.wrappedValue` would always be `AnyHashable<AnyHashable<MyScreen>>` in iOS 14.3.
So I made this PR to get the real `base` value.

