### PR TITLE
Updating migration docs to include Hashable for enum in new API

### DIFF
--- a/Docs/Migration/Migrating to 1.0.md
+++ b/Docs/Migration/Migrating to 1.0.md
@@ -41,7 +41,7 @@ struct AppCoordinator: View {
  <summary>New API</summary>
 
 ```swift
-enum Screen {
+enum Screen: Hashable {
   case numberList
   case numberDetail(Int)
 }


### PR DESCRIPTION
When migrating to the new API, I noticed that `Hashable` conformance is now a requirement for the Screen enum. That wasn't clearly described in the code example, so adding it here.