### PR TITLE
Added public initializer for FlowNavigator

### DIFF
--- a/Sources/FlowStacks/FlowNavigator.swift
+++ b/Sources/FlowStacks/FlowNavigator.swift
@@ -14,7 +14,7 @@ public class FlowNavigator<Screen>: ObservableObject {
     set { routesBinding.wrappedValue = newValue }
   }
 
-  init(_ routesBinding: Binding<[Route<Screen>]>) {
+  public init(_ routesBinding: Binding<[Route<Screen>]>) {
     self.routesBinding = routesBinding
   }
 }


### PR DESCRIPTION
**Description:**
For purpose of unit testing eg with [ViewInspector](https://github.com/nalexn/ViewInspector) it is necessary to inject manually the environment object to the view, such as:

```swift
let sut = SomeView(dismiss: dismiss)
            .environmentObject(FlowPathNavigator(.constant([])))
            .prepareForInspection()
        
        let exp1:XCTestExpectation = sut
            .inspection
            .inspect { v in
                XCTAssertNoThrow(try v.find(text: self.title))
            }
        
        ViewHosting.host(view: sut)
        wait(for: [exp1], timeout: 1)
```

If there is no need to have the initializer for FlowNavigator internal, this PR makes it public.