### PR TITLE
Add popAndPush convenience method (fixes #110)

### DIFF
--- a/Sources/FlowStacks/Convenience methods/Array+convenienceMethods.swift
+++ b/Sources/FlowStacks/Convenience methods/Array+convenienceMethods.swift
@@ -278,6 +278,18 @@ public extension Array where Element: RouteProtocol, Element.Screen: Identifiabl
   }
 }
 
+// MARK: - Pop and push
+
+public extension Array where Element: RouteProtocol {
+  /// Pops the top pushed screen and pushes a new screen, resulting in a push transition to the new screen.
+  /// Only the top screen will be popped, and it must have been pushed (not presented).
+  /// - Parameter screen: The new screen to push.
+  mutating func popAndPush(_ screen: Element.Screen) {
+    pop()
+    push(screen)
+  }
+}
+
 // MARK: - Dismiss
 
 public extension Array where Element: RouteProtocol {

--- a/Sources/FlowStacks/Convenience methods/FlowNavigator+convenienceMethods.swift
+++ b/Sources/FlowStacks/Convenience methods/FlowNavigator+convenienceMethods.swift
@@ -256,6 +256,17 @@ public extension FlowNavigator where Screen == AnyHashable {
   }
 }
 
+// MARK: - Pop and push
+
+public extension FlowNavigator {
+  /// Pops the top pushed screen and pushes a new screen, resulting in a push transition to the new screen.
+  /// Only the top screen will be popped, and it must have been pushed (not presented).
+  /// - Parameter screen: The new screen to push.
+  func popAndPush(_ screen: Screen) {
+    routes.popAndPush(screen)
+  }
+}
+
 // MARK: - Dismiss
 
 public extension FlowNavigator {

--- a/Sources/FlowStacks/Convenience methods/FlowPath+convenienceMethods.swift
+++ b/Sources/FlowStacks/Convenience methods/FlowPath+convenienceMethods.swift
@@ -180,6 +180,17 @@ public extension FlowPath {
   }
 }
 
+// MARK: - Pop and push
+
+public extension FlowPath {
+  /// Pops the top pushed screen and pushes a new screen, resulting in a push transition to the new screen.
+  /// Only the top screen will be popped, and it must have been pushed (not presented).
+  /// - Parameter screen: The new screen to push.
+  mutating func popAndPush(_ screen: AnyHashable) {
+    routes.popAndPush(screen)
+  }
+}
+
 // MARK: - Dismiss
 
 public extension FlowPath {

--- a/Tests/FlowStacksTests/ConvenienceMethodsTests.swift
+++ b/Tests/FlowStacksTests/ConvenienceMethodsTests.swift
@@ -86,6 +86,24 @@ final class ConvenienceMethodsTests: XCTestCase {
     XCTAssertEqual(path.count, 2)
   }
 
+  func testPopAndPush() {
+    var path = FlowPath([.push(1), .push("two"), .push(true)])
+    path.popAndPush("three")
+    XCTAssertEqual(path.count, 3)
+    // Last route should be a push of the new screen
+    XCTAssertEqual(path.routes.last?.style, .push)
+    XCTAssertEqual(path.routes.last?.screen as? String, "three")
+    // Previous screen should be unchanged
+    XCTAssertEqual(path.routes[1].screen as? String, "two")
+  }
+
+  func testPopAndPushFromSingleScreen() {
+    var path = FlowPath([.push(1)])
+    path.popAndPush("replacement")
+    XCTAssertEqual(path.count, 1)
+    XCTAssertEqual(path.routes.last?.screen as? String, "replacement")
+  }
+
   func testDismissAllWhereFirstIsPushed() {
     var path = FlowPath([.push(1), .sheet("two"), .push(3), .cover("four"), .push(5), .cover("six"), .push(7)])
     path.dismiss()


### PR DESCRIPTION
Picked up issue #110 — the ask was for a way to pop the current screen and push a new one with a proper push animation.

The problem with the current workaround of calling pop() and push() separately is that they fire as two distinct state updates, so SwiftUI only animates the pop and the push transition never happens. Not a great experience when you're trying to replace screen B with screen C and want it to feel like a forward navigation.

The fix is a pop​And​Push(_ screen:) method that performs both operations on the routes array in a single mutation. Since the net change is committed atomically, calculate​Steps(from​:to:) sees it as "pop, then push" and sequences the two animations correctly — you get the full push transition as expected.

Added the method to Array (the core implementation), Flow​Path, and Flow​Navigator to match the pattern of every other convenience method in the library. Also included unit tests covering replacing the top screen in a multi-screen stack and in a single-screen stack.